### PR TITLE
Add 3D model viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Python 3.12 is expected (see `runtime.txt`). A dev container configuration is in
 
 After launching the app you will be prompted to upload an IFC file. The interface lets you edit project metadata, beneficiary details, land registration fields and the site address. When you apply the changes, an updated IFC file becomes available for download.
 
+The app is multipage. In the sidebar you can switch to **"Vizualizare IFC 3D"** which opens a viewer for inspecting your model directly in the browser.
+
 
 ## Demo
 
@@ -31,4 +33,5 @@ A live demo is available at [https://ifcplan-de-situatie-v0.streamlit.app/](http
 - `requirements.txt` – Python dependencies.
 - `runtime.txt` – Python runtime version for deployments.
 - `buildingsmart_romania_logo.jpg` – Logo displayed in the app.
+- `pages/1_3D_Viewer.py` – Optional page that renders a 3D preview of the IFC model.
 

--- a/pages/1_3D_Viewer.py
+++ b/pages/1_3D_Viewer.py
@@ -1,0 +1,33 @@
+import streamlit as st
+from streamlit.components.v1 import html
+import base64
+
+st.set_page_config(page_title="Vizualizare IFC 3D", layout="wide")
+
+st.title("Vizualizare IFC 3D")
+
+uploaded_file = st.file_uploader("Încărcați un fișier IFC", type=["ifc"], accept_multiple_files=False)
+
+if uploaded_file is not None:
+    b64_ifc = base64.b64encode(uploaded_file.getvalue()).decode()
+    viewer_html = f"""
+    <div id='viewer-container' style='width: 100%; height: 750px;'></div>
+    <script type='module'>
+      import {{ IfcViewerAPI }} from 'https://cdn.jsdelivr.net/npm/web-ifc-viewer@latest/dist/ifc-viewer-api.js';
+      const container = document.getElementById('viewer-container');
+      const viewer = new IfcViewerAPI({{ container }});
+      viewer.grid.setGrid();
+      viewer.axes.setAxes();
+      const binaryString = atob('{b64_ifc}');
+      const len = binaryString.length;
+      const bytes = new Uint8Array(len);
+      for (let i = 0; i < len; i++) {{
+          bytes[i] = binaryString.charCodeAt(i);
+      }}
+      const url = URL.createObjectURL(new Blob([bytes]));
+      await viewer.IFC.loadIfcUrl(url);
+    </script>
+    """
+    html(viewer_html, height=750)
+else:
+    st.info("Încărcați un fișier IFC pentru a-l vizualiza în 3D.")


### PR DESCRIPTION
## Summary
- add `pages/1_3D_Viewer.py` with an embedded `web-ifc-viewer`
- document the new viewer page in README
- fix string formatting for the 3D viewer

## Testing
- `python -m py_compile ifc_land_registration_app.py pages/1_3D_Viewer.py`


------
https://chatgpt.com/codex/tasks/task_e_68449000b88c8329915929c355f1d4a7