### PR TITLE
Improve large IFC handling with fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ ENV/
 *.tmp
 *.log
 
+# Node
+node_modules/
+package-lock.json
+

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This repository contains a small Streamlit application for enriching IFC files w
 
 ## Running locally
 
-1. Install the requirements:
+1. Install the requirements (and Node dependencies):
    ```bash
    pip install -r requirements.txt
+   npm install
    ```
 2. Launch the app:
    ```bash
@@ -19,6 +20,8 @@ Python 3.12 is expected (see `runtime.txt`). A dev container configuration is in
 ## Usage
 
 After launching the app you will be prompted to upload an IFC file. The interface lets you edit project metadata, beneficiary details, land registration fields and the site address. When you apply the changes, an updated IFC file becomes available for download.
+
+Large IFC files are converted to the lightweight **Fragments** format before visualization to keep the viewer responsive. The conversion relies on the included `convert_to_fragments.js` script and Node.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ This repository contains a small Streamlit application for enriching IFC files w
    pip install -r requirements.txt
    npm install
    ```
+   The fragment converter requires Node 18+ to be available on the system.
+   When deploying to Streamlit Cloud, create a `packages.txt` file containing
+   the following lines so Node gets installed:
+
+   ```
+   nodejs
+   npm
+   ```
 2. Launch the app:
    ```bash
    streamlit run ifc_land_registration_app.py
@@ -21,7 +29,7 @@ Python 3.12 is expected (see `runtime.txt`). A dev container configuration is in
 
 After launching the app you will be prompted to upload an IFC file. The interface lets you edit project metadata, beneficiary details, land registration fields and the site address. When you apply the changes, an updated IFC file becomes available for download.
 
-Large IFC files are converted to the lightweight **Fragments** format before visualization to keep the viewer responsive. The conversion relies on the included `convert_to_fragments.js` script and Node.
+Large IFC files are converted to the lightweight **Fragments** format before visualization to keep the viewer responsive. The conversion relies on the included `convert_to_fragments.js` script and Node. If Node isn't present, the app falls back to client-side conversion which can be slower for big models.
 
 ## Demo
 

--- a/convert_to_fragments.js
+++ b/convert_to_fragments.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const { IfcImporter } = require('@thatopen/fragments');
+
+async function main() {
+  const [input, output] = process.argv.slice(2);
+  if (!input || !output) {
+    console.error('Usage: node convert_to_fragments.js <input.ifc> <output.ifcfrag>');
+    process.exit(1);
+  }
+
+  const bytes = fs.readFileSync(input);
+  const importer = new IfcImporter();
+  importer.wasm = { absolute: true, path: path.resolve(__dirname, 'node_modules/web-ifc/') + '/' };
+
+  try {
+    const frag = await importer.process({ bytes });
+    fs.writeFileSync(output, Buffer.from(frag));
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ifc_plan-de-situatie",
+  "version": "1.0.0",
+  "description": "This repository contains a small Streamlit application for enriching IFC files with site and land registration information in Romanian.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@thatopen/fragments": "^3.0.7",
+    "web-ifc": "^0.0.68"
+  }
+}

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,2 @@
+nodejs
+npm


### PR DESCRIPTION
## Summary
- ignore Node artifacts
- include a Node converter script to pre-process IFC to Fragments
- convert uploads to fragments before embedding in the viewer
- document new node setup and fragments in the README

## Testing
- `python -m py_compile ifc_land_registration_app.py`
- `node convert_to_fragments.js minimal.ifc minimal.ifcfrag` *(fails on invalid files)*


------
https://chatgpt.com/codex/tasks/task_e_6845fe2c8a7483298b38fbdfedfd0fa0