### PR TITLE
Improve viewer performance for large IFCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Python 3.12 is expected (see `runtime.txt`). A dev container configuration is in
 
 After launching the app you will be prompted to upload an IFC file. The interface lets you edit project metadata, beneficiary details, land registration fields and the site address. When you apply the changes, an updated IFC file becomes available for download.
 
+The embedded 3D viewer only loads IFCs up to 8 MB. Larger files can still be edited and downloaded but won't be previewed to avoid browser crashes.
+
 ## Demo
 
 A live demo is available at [https://ifcplan-de-situatie-v0.streamlit.app/](https://ifcplan-de-situatie-v0.streamlit.app/).

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Python 3.12 is expected (see `runtime.txt`). A dev container configuration is in
 
 After launching the app you will be prompted to upload an IFC file. The interface lets you edit project metadata, beneficiary details, land registration fields and the site address. When you apply the changes, an updated IFC file becomes available for download.
 
-The embedded 3D viewer only loads IFCs up to 8 MB. Larger files can still be edited and downloaded but won't be previewed to avoid browser crashes.
-
 ## Demo
 
 A live demo is available at [https://ifcplan-de-situatie-v0.streamlit.app/](https://ifcplan-de-situatie-v0.streamlit.app/).

--- a/ifc_land_registration_app.py
+++ b/ifc_land_registration_app.py
@@ -63,8 +63,6 @@ ROM_COUNTIES_BASE = [
 DEFAULT_JUDET_PROMPT = "--- Selectați județul ---"
 UI_ROM_COUNTIES = [DEFAULT_JUDET_PROMPT] + ROM_COUNTIES_BASE
 
-# Maximum IFC size (in bytes) that will be displayed in the embedded viewer
-MAX_VIEWER_BYTES =  20 * 1024 * 1024  # 200 MB
 
 # ----------------------------------------------------------
 # Funcții helper
@@ -144,7 +142,6 @@ uploaded_file = st.file_uploader("Încarcă un fișier IFC", type=["ifc"], accep
 if uploaded_file:
     file_bytes = uploaded_file.getvalue()
     model = load_ifc_from_upload(file_bytes)
-    file_size = len(file_bytes)
     
     project = get_project(model)
     if project is None:
@@ -156,44 +153,39 @@ if uploaded_file:
         st.error("Nu s-a găsit niciun IfcSite în modelul încărcat.")
         st.stop()
 
-    if file_size <= MAX_VIEWER_BYTES:
-        b64_ifc = base64.b64encode(file_bytes).decode()
-        viewer_html = f"""
-        <div id='viewer-container' style='width: 100%; height: 600px;'></div>
-        <script>
-            // Prevent libraries from thinking we run in Node and CommonJS
-            window.process = {{ versions: {{}} }};
-            window.module = {{}};
-        </script>
-        <script type='module'>
-            import * as OBC from 'https://esm.sh/openbim-components@1.5.1?bundle';
-            import * as FRAGS from 'https://esm.sh/@thatopen/fragments?bundle';
+    b64_ifc = base64.b64encode(file_bytes).decode()
+    viewer_html = f"""
+    <div id='viewer-container' style='width: 100%; height: 600px;'></div>
+    <script>
+        // Prevent libraries from thinking we run in Node and CommonJS
+        window.process = {{ versions: {{}} }};
+        window.module = {{}};
+    </script>
+    <script type='module'>
+        import * as OBC from 'https://esm.sh/openbim-components@1.5.1?bundle';
+        import * as FRAGS from 'https://esm.sh/@thatopen/fragments?bundle';
 
-            const components = new OBC.Components();
-            components.scene = new OBC.SimpleScene(components);
-            const container = document.getElementById('viewer-container');
-            components.renderer = new OBC.SimpleRenderer(components, container);
-            components.camera = new OBC.SimpleCamera(components);
-            await components.init();
-            await components.scene.setup();
+        const components = new OBC.Components();
+        components.scene = new OBC.SimpleScene(components);
+        const container = document.getElementById('viewer-container');
+        components.renderer = new OBC.SimpleRenderer(components, container);
+        components.camera = new OBC.SimpleCamera(components);
+        await components.init();
+        await components.scene.setup();
 
-            const importer = new FRAGS.IfcImporter();
-            importer.wasm = {{ absolute: true, path: 'https://cdn.jsdelivr.net/npm/web-ifc@0.0.68/' }};
-            const workerUrl = 'https://thatopen.github.io/engine_fragment/resources/worker.mjs';
-            const fragments = new FRAGS.FragmentsModels(workerUrl);
+        const importer = new FRAGS.IfcImporter();
+        importer.wasm = {{ absolute: true, path: 'https://cdn.jsdelivr.net/npm/web-ifc@0.0.68/' }};
+        const workerUrl = 'https://thatopen.github.io/engine_fragment/resources/worker.mjs';
+        const fragments = new FRAGS.FragmentsModels(workerUrl);
 
-            const base64Data = '{b64_ifc}';
-            const ifcBytes = Uint8Array.from(atob(base64Data), c => c.charCodeAt(0));
-            const fragBytes = await importer.process({ bytes: ifcBytes });
-            const model = await fragments.load(fragBytes, {{ modelId: 'model' }});
-            components.scene.get().add(model.object);
-        </script>
-        """
-        st.components.v1.html(viewer_html, height=600)
-    else:
-        st.info(
-            'Fișierul IFC este prea mare pentru a fi previzualizat. Poate fi totuși modificat și descărcat.'
-        )
+        const base64Data = '{b64_ifc}';
+        const ifcBytes = Uint8Array.from(atob(base64Data), c => c.charCodeAt(0));
+        const fragBytes = await importer.process({{ bytes: ifcBytes }});
+        const model = await fragments.load(fragBytes, {{ modelId: 'model' }});
+        components.scene.get().add(model.object);
+    </script>
+    """
+    st.components.v1.html(viewer_html, height=600)
 
     with st.expander("Informații proiect", expanded=True):
         project_name      = st.text_input("Număr proiect", value=project.Name or "")

--- a/ifc_land_registration_app.py
+++ b/ifc_land_registration_app.py
@@ -64,7 +64,7 @@ DEFAULT_JUDET_PROMPT = "--- Selectați județul ---"
 UI_ROM_COUNTIES = [DEFAULT_JUDET_PROMPT] + ROM_COUNTIES_BASE
 
 # Maximum IFC size (in bytes) that will be displayed in the embedded viewer
-MAX_VIEWER_BYTES = 8 * 1024 * 1024  # 8 MB
+MAX_VIEWER_BYTES =  20 * 1024 * 1024  # 200 MB
 
 # ----------------------------------------------------------
 # Funcții helper

--- a/ifc_land_registration_app.py
+++ b/ifc_land_registration_app.py
@@ -174,7 +174,7 @@ if uploaded_file:
         await components.scene.setup();
 
         const importer = new FRAGS.IfcImporter();
-        importer.wasm = { absolute: true, path: 'https://cdn.jsdelivr.net/npm/web-ifc@0.0.68/' };
+        importer.wasm = {{ absolute: true, path: 'https://cdn.jsdelivr.net/npm/web-ifc@0.0.68/' }};
         const workerUrl = 'https://thatopen.github.io/engine_fragment/resources/worker.mjs';
         const fragments = new FRAGS.FragmentsModels(workerUrl);
         components.camera.controls.addEventListener('rest', () => fragments.update(true));

--- a/ifc_land_registration_app.py
+++ b/ifc_land_registration_app.py
@@ -174,15 +174,19 @@ if uploaded_file:
         await components.scene.setup();
 
         const importer = new FRAGS.IfcImporter();
-        importer.wasm = {{ absolute: true, path: 'https://cdn.jsdelivr.net/npm/web-ifc@0.0.68/' }};
+        importer.wasm = { absolute: true, path: 'https://cdn.jsdelivr.net/npm/web-ifc@0.0.68/' };
         const workerUrl = 'https://thatopen.github.io/engine_fragment/resources/worker.mjs';
         const fragments = new FRAGS.FragmentsModels(workerUrl);
+        components.camera.controls.addEventListener('rest', () => fragments.update(true));
+        components.camera.controls.addEventListener('update', () => fragments.update());
 
         const base64Data = '{b64_ifc}';
         const ifcBytes = Uint8Array.from(atob(base64Data), c => c.charCodeAt(0));
         const fragBytes = await importer.process({{ bytes: ifcBytes }});
         const model = await fragments.load(fragBytes, {{ modelId: 'model' }});
+        model.useCamera(components.camera.three);
         components.scene.get().add(model.object);
+        await fragments.update(true);
     </script>
     """
     st.components.v1.html(viewer_html, height=600)


### PR DESCRIPTION
## Summary
- limit in-browser viewer to 8 MB IFC files
- load viewer using `IfcImporter` from `@thatopen/fragments`
- reuse uploaded bytes to avoid duplicate reads
- document viewer size limitation

## Testing
- `python -m py_compile ifc_land_registration_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846d68fb8048329a658710f13460e8e